### PR TITLE
Add ability to send syslog RFC5424 structured_data

### DIFF
--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -80,9 +80,11 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   # message id for syslog message
   config :msgid, :validate => :string, :default => "-"
 
+  # structured data for syslog message (rfc5424 only)
+  config :structured_data, :validate => :string, :default => "-"
+
   # syslog message format: you can choose between rfc3164 or rfc5424
   config :rfc, :validate => ["rfc3164", "rfc5424"], :default => "rfc3164"
-
   
   public
   def register
@@ -127,9 +129,10 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
       timestamp = event.sprintf("%{+MMM dd HH:mm:ss}")
       syslog_msg = "<"+priority.to_s()+">"+timestamp+" "+sourcehost+" "+appname+"["+procid+"]: "+event["message"]
     else
-      msgid = event.sprintf(@msgid)
+      msgid = event.sprintf(@msgid) 
+      structured_data = "[LOGSTASH@#{LOGSTASH_VERSION} #{event.sprintf(@structured_data)}]" unless @structured_data == '-'
       timestamp = event.sprintf("%{+YYYY-MM-dd'T'HH:mm:ss.SSSZ}")
-      syslog_msg = "<"+priority.to_s()+">1 "+timestamp+" "+sourcehost+" "+appname+" "+procid+" "+msgid+" - "+event["message"]
+      syslog_msg = "<"+priority.to_s()+">1 "+timestamp+" "+sourcehost+" "+appname+" "+procid+" "+msgid+" "+structured_data+" "+event["message"]
     end
 
     begin


### PR DESCRIPTION
Currently the syslog output always sets the [syslog RFC5424 structured data](https://tools.ietf.org/html/rfc5424#section-6.3) field to `-`.

The PR adds the ability to send customised [syslog RFC5424 structured data](https://tools.ietf.org/html/rfc5424#section-6.3) for the syslog output.

This is really helpful if you want to pass additional "meta data" along with your syslog message.

ie.

```
syslog {
    host => "10.244.10.6"
    port => 514
    rfc => "rfc5424"
    facility => "user-level"
    severity => "informational"
    structured_data => '@extrafield="%{[@extrafield]}"'
}
```

will result in syslog messages that look this this:

```
<14>1 2015-01-16T11:49:18.670+0000 logsearch-workspace LOGSTASH - - [LOGSTASH@1.4.0 extrafield="extrafield_value"] 75.71.143.76, 10.10.2.122 - - - [13/Jan/2015:15:19:05 +0000] "GET /favicon.ico HTTP/1.1" 404 199
```

Omitting the structured_data field

```
syslog {
    host => "10.244.10.6"
    port => 514
    rfc => "rfc5424"
    facility => "user-level"
    severity => "informational"
}
```

Keeps the existing behaviour of sending `-`

```
<14>1 2015-01-16T11:49:18.670+0000 logsearch-workspace LOGSTASH - - - 75.71.143.76, 10.10.2.122 - - - [13/Jan/2015:15:19:05 +0000] "GET /favicon.ico HTTP/1.1" 404 199
```