### PR TITLE
Fix RFC5424 timestamp output

### DIFF
--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -136,7 +136,7 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
       syslog_msg = "<"+priority.to_s()+">"+timestamp+" "+sourcehost+" "+appname+"["+procid+"]: "+event.sprintf(@message)
     else
       msgid = event.sprintf(@msgid)
-      timestamp = event.sprintf("%{+YYYY-MM-dd'T'HH:mm:ss.SSSZ}")
+      timestamp = event.sprintf("%{+YYYY-MM-dd'T'HH:mm:ss.SSSZZ}")
       syslog_msg = "<"+priority.to_s()+">1 "+timestamp+" "+sourcehost+" "+appname+" "+procid+" "+msgid+" - "+event.sprintf(@message)
     end
 


### PR DESCRIPTION
This fixes issue #3, "RFC5424 output seems to format zone offset incorrectly"

Adding the second 'Z' to the timestamp format outputs the offset with the colon ([see date format docs here](http://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html)). I tested this with syslog-ng as the receiving syslog and it now happily accepts RFC5424 messages sent to it via logstash-output-syslog where before it complained and wouldn't parse them. 