### PR TITLE
reconnect on exception - backport to core-api-v1 of pr #13

### DIFF
--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -57,9 +57,12 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
   # syslog server address to connect to
   config :host, :validate => :string, :required => true
-  
+
   # syslog server port to connect to
   config :port, :validate => :number, :required => true
+
+  # when connection fails, retry interval in sec.
+  config :reconnect_interval, :validate => :number, :default => 1
 
   # syslog server protocol. you can choose between udp and tcp
   config :protocol, :validate => ["tcp", "udp"], :default => "udp"
@@ -84,40 +87,24 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
   # message text to log
   config :message, :validate => :string, :default => "%{message}"
- 
+
   # message id for syslog message
   config :msgid, :validate => :string, :default => "-"
 
   # syslog message format: you can choose between rfc3164 or rfc5424
   config :rfc, :validate => ["rfc3164", "rfc5424"], :default => "rfc3164"
 
-  
-  public
   def register
-      @client_socket = nil
+    @client_socket = nil
+
+    facility_code = FACILITY_LABELS.index(@facility)
+    severity_code = SEVERITY_LABELS.index(@severity)
+    @priority = (facility_code * 8) + severity_code
+
+    # use instance variable to avoid string comparison for each event
+    @is_rfc3164 = (@rfc == "rfc3164")
   end
 
-  private
-  def udp?
-    @protocol == "udp"
-  end
-
-  private
-  def rfc3164?
-    @rfc == "rfc3164"
-  end 
-
-  private
-  def connect
-    if udp?
-        @client_socket = UDPSocket.new
-        @client_socket.connect(@host, @port)
-    else
-        @client_socket = TCPSocket.new(@host, @port)
-    end
-  end
-
-  public
   def receive(event)
     return unless output?(event)
 
@@ -125,30 +112,42 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
     procid = event.sprintf(@procid)
     sourcehost = event.sprintf(@sourcehost)
 
-    facility_code = FACILITY_LABELS.index(@facility)
-
-    severity_code = SEVERITY_LABELS.index(@severity)
-
-    priority = (facility_code * 8) + severity_code
-
-    if rfc3164?
+    if @is_rfc3164
       timestamp = event.sprintf("%{+MMM dd HH:mm:ss}")
-      syslog_msg = "<"+priority.to_s()+">"+timestamp+" "+sourcehost+" "+appname+"["+procid+"]: "+event.sprintf(@message)
+      syslog_msg = "<#{@priority.to_s}>#{timestamp} #{sourcehost} #{appname}[#{procid}]: #{event.sprintf(@message)}"
     else
       msgid = event.sprintf(@msgid)
       timestamp = event.sprintf("%{+YYYY-MM-dd'T'HH:mm:ss.SSSZZ}")
-      syslog_msg = "<"+priority.to_s()+">1 "+timestamp+" "+sourcehost+" "+appname+" "+procid+" "+msgid+" - "+event.sprintf(@message)
+      syslog_msg = "<#{@priority.to_s}>1 #{timestamp} #{sourcehost} #{appname} #{procid} #{msgid} - #{event.sprintf(@message)}"
     end
 
     begin
-      connect unless @client_socket
+      @client_socket ||= connect
       @client_socket.write(syslog_msg + "\n")
     rescue => e
-      @logger.warn(@protocol+" output exception", :host => @host, :port => @port,
-                 :exception => e, :backtrace => e.backtrace)
+      @logger.warn("syslog " + @protocol + " output exception: closing, reconnecting and resending event", :host => @host, :port => @port, :exception => e, :backtrace => e.backtrace, :event => event)
       @client_socket.close rescue nil
       @client_socket = nil
+
+      sleep(@reconnect_interval)
+      retry
     end
   end
-end
 
+  private
+
+  def udp?
+    @protocol == "udp"
+  end
+
+  def connect
+    socket = nil
+    if udp?
+      socket = UDPSocket.new
+      socket.connect(@host, @port)
+    else
+      socket = TCPSocket.new(@host, @port)
+    end
+    socket
+  end
+end

--- a/logstash-output-syslog.gemspec
+++ b/logstash-output-syslog.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency 'logstash-codec-plain'
 end
 

--- a/logstash-output-syslog.gemspec
+++ b/logstash-output-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-syslog'
-  s.version         = '0.1.4'
+  s.version         = '0.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send events to a syslog server."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/syslog_spec.rb
+++ b/spec/outputs/syslog_spec.rb
@@ -1,1 +1,50 @@
+# encoding: utf-8
+
 require "logstash/devutils/rspec/spec_helper"
+require "logstash/outputs/syslog"
+
+describe LogStash::Outputs::Syslog do
+
+  it "should register without errors" do
+    plugin = LogStash::Plugin.lookup("output", "syslog").new({"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency"})
+    expect { plugin.register }.to_not raise_error
+  end
+
+  subject do
+    plugin = LogStash::Plugin.lookup("output", "syslog").new(options)
+    plugin.register
+    plugin
+  end
+
+  let(:socket) { double("fake socket") }
+  let(:event) { LogStash::Event.new({"message" => "bar", "host" => "baz"}) }
+
+  shared_examples "syslog output" do
+    it "should write expected format" do
+      expect(subject).to receive(:connect).and_return(socket)
+      expect(socket).to receive(:write).with(output)
+      subject.receive(event)
+    end
+  end
+
+  context "rfc 3164 and udp by default" do
+    let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency"} }
+    let(:output) { /^<0>.+baz LOGSTASH\[-\]: bar\n/m }
+
+    it_behaves_like "syslog output"
+  end
+
+  context "rfc 5424 and tcp" do
+    let(:options) { {"rfc" => "rfc5424", "protocol" => "tcp", "host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency"} }
+    let(:output) { /^<0>1 .+baz LOGSTASH - - - bar\n/m }
+
+    it_behaves_like "syslog output"
+  end
+
+  context "calculate priority" do
+    let(:options) { {"host" => "foo", "port" => "123", "facility" => "mail", "severity" => "critical"} }
+    let(:output) { /^<18>.+baz LOGSTASH\[-\]: bar\n/m }
+
+    it_behaves_like "syslog output"
+  end
+end


### PR DESCRIPTION
differences:
- version of the gemspec
- first line of the `receive` method which has `return unless output?(event)`