### PR TITLE
Remove deprecated config for 5.0 + migrate to new event api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
-# 2.1.5
+## 3.0.0
+ - breaking,config: Remove deprecated `timestamp` config.
+ - internal: migrate to Logstash Event API 2.0
+
+## 2.1.5
  - [Internal] test fix to not depend on json order
-# 2.1.4
+
+## 2.1.4
  - [Internal] fix tests
-# 2.1.3
+
+## 2.1.3
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.1.2
+
+## 2.1.2
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.1.1
  - Add SSL/TLS support to syslog output plugin (thanks @breml)
  - Added ability to use codecs for this output (thanks @breml)

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -106,9 +106,6 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   # to help you build a new value from other parts of the event.
   config :sourcehost, :validate => :string, :default => "%{host}"
 
-  # timestamp for syslog message
-  config :timestamp, :validate => :string, :default => "%{@timestamp}", :deprecated => "This setting is no longer necessary. The RFC setting will determine what time format is used."
-
   # application name for syslog message. The new value can include `%{foo}` strings
   # to help you build a new value from other parts of the event.
   config :appname, :validate => :string, :default => "LOGSTASH"

--- a/logstash-output-syslog.gemspec
+++ b/logstash-output-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-syslog'
-  s.version         = '2.1.5'
+  s.version         = '3.0.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send events to a syslog server."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
   s.add_runtime_dependency 'logstash-codec-plain'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
Meta-issue for removing deprecated config => https://github.com/elastic/logstash/issues/3858

Note: this plugin is so dynamic with usage of codec and event.sprintf that no code-change was required for the event api migration :+1: 
