### PR TITLE
Logstash-output-syslog questions / improvements for central log hub towards other SIEM/Compliancy tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.2
+  - Added rfc3164 compatibility for timestamp (space / no zero-padding) and made the procid optional. Ref: https://www.ietf.org/rfc/rfc3164.txt
+
 ## 3.0.1
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,7 @@ Contributors:
 * Richard Pijnenburg (electrical)
 * ruckalvnet
 * Lucas Bremgartner (breml)
+* Arnold van Wijnbergen (avwsolutions)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -165,7 +165,6 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
     end
 
     if @is_rfc3164
-      procid_rfc3164 = "["+procid+"]"
       timestamp_tmp = event.sprintf("%{+MMM dd HH:mm:ss}")
       
       if timestamp_tmp[4].to_i == 0
@@ -173,8 +172,13 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
       else
         timestamp = event.sprintf("%{+MMM d HH:mm:ss}") 
       end
+      
+      if @procid
+        syslog_msg = "<#{priority.to_s}>#{timestamp} #{sourcehost} #{appname}[#{procid}]: #{message}"
+      else
+        syslog_msg = "<#{priority.to_s}>#{timestamp} #{sourcehost} #{appname}: #{message}"
+      end
 
-      syslog_msg = "<#{priority.to_s}>#{timestamp} #{sourcehost} #{appname}#{procid_rfc3164}: #{message}"
     else
       msgid = event.sprintf(@msgid)
       timestamp = event.sprintf("%{+YYYY-MM-dd'T'HH:mm:ss.SSSZZ}")

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -112,7 +112,7 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
   # process id for syslog message. The new value can include `%{foo}` strings
   # to help you build a new value from other parts of the event.
-  config :procid, :validate => :string, :default => "-"
+  config :procid, :validate => :string, :default => nil 
 
   # message text to log. The new value can include `%{foo}` strings
   # to help you build a new value from other parts of the event.
@@ -165,8 +165,16 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
     end
 
     if @is_rfc3164
-      timestamp = event.sprintf("%{+MMM dd HH:mm:ss}")
-      syslog_msg = "<#{priority.to_s}>#{timestamp} #{sourcehost} #{appname}[#{procid}]: #{message}"
+      procid_rfc3164 = "["+procid+"]"
+      timestamp_tmp = event.sprintf("%{+MMM dd HH:mm:ss}")
+      
+      if timestamp_tmp[4].to_i == 0
+        timestamp = event.sprintf("%{+MMM  d HH:mm:ss}") 
+      else
+        timestamp = event.sprintf("%{+MMM d HH:mm:ss}") 
+      end
+
+      syslog_msg = "<#{priority.to_s}>#{timestamp} #{sourcehost} #{appname}#{procid_rfc3164}: #{message}"
     else
       msgid = event.sprintf(@msgid)
       timestamp = event.sprintf("%{+YYYY-MM-dd'T'HH:mm:ss.SSSZZ}")

--- a/logstash-output-syslog.gemspec
+++ b/logstash-output-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-syslog'
-  s.version         = '3.0.1'
+  s.version         = '3.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Send events to a syslog server."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/syslog_spec.rb
+++ b/spec/outputs/syslog_spec.rb
@@ -7,7 +7,7 @@ require "json"
 
 describe LogStash::Outputs::Syslog do
 
-  RFC3164_DATE_TIME_REGEX = "(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)"
+  RFC3164_DATE_TIME_REGEX = "(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\s|[1-3])([1-9]|[12][0-9]|3[01]) ([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)"
   RFC3339_DATE_TIME_REGEX = "([0-9]+)-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])[Tt]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(\.[0-9]{3})?([Zz]|([+-]([01][0-9]|2[0-3]):[0-5][0-9]))"
 
   it "should register without errors" do
@@ -34,13 +34,13 @@ describe LogStash::Outputs::Syslog do
 
   context "rfc 3164 and udp by default" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency"} }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: bar\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
 
     it_behaves_like "syslog output"
   end
 
   context "rfc 5424 and tcp" do
-    let(:options) { {"rfc" => "rfc5424", "protocol" => "tcp", "host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency"} }
+    let(:options) { {"rfc" => "rfc5424", "protocol" => "tcp", "host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency", "procid" => "-" } }
     let(:output) { /^<0>1 #{RFC3339_DATE_TIME_REGEX} baz LOGSTASH - - - bar\n/m }
 
     it_behaves_like "syslog output"
@@ -48,7 +48,7 @@ describe LogStash::Outputs::Syslog do
 
   context "calculate priority" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "mail", "severity" => "critical"} }
-    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: bar\n/m }
+    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -72,7 +72,7 @@ describe LogStash::Outputs::Syslog do
   context "use_labels == false, default" do
     let(:event) { LogStash::Event.new({"message" => "bar", "host" => "baz" }) }
     let(:options) { {"use_labels" => false, "host" => "foo", "port" => "123" } }
-    let(:output) { /^<13>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: bar\n/m }
+    let(:output) { /^<13>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -80,7 +80,7 @@ describe LogStash::Outputs::Syslog do
   context "use_labels == false, syslog_pri" do
     let(:event) { LogStash::Event.new({"message" => "bar", "host" => "baz", "syslog_pri" => "18" }) }
     let(:options) { {"use_labels" => false, "host" => "foo", "port" => "123" } }
-    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: bar\n/m }
+    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -88,7 +88,7 @@ describe LogStash::Outputs::Syslog do
   context "use_labels == false, sprintf" do
     let(:event) { LogStash::Event.new({"message" => "bar", "host" => "baz", "priority" => "18" }) }
     let(:options) { {"use_labels" => false, "host" => "foo", "port" => "123", "priority" => "%{priority}" } }
-    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: bar\n/m }
+    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -96,7 +96,7 @@ describe LogStash::Outputs::Syslog do
   context "use plain codec with format set" do
     let(:plain) { LogStash::Codecs::Plain.new({"format" => "%{host} %{message}"}) }
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency", "codec" => plain} }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: baz bar\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: baz bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -107,7 +107,7 @@ describe LogStash::Outputs::Syslog do
     it "should write event encoded with json codec" do
       expect(subject).to receive(:connect).and_return(socket)
       expect(socket).to receive(:write) do |arg|
-        message = arg[/^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: (.*)/, 1]
+        message = arg[/^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: (.*)/, 1]
         expect(message).not_to be_nil
         message_json = JSON.parse(message)
         expect(message_json).to include("@timestamp")
@@ -121,21 +121,21 @@ describe LogStash::Outputs::Syslog do
 
   context "escape carriage return, newline and newline to \\n" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency", "message" => "foo\r\nbar\nbaz" } }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: foo\\nbar\\nbaz\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: foo\\nbar\\nbaz\n/m }
 
     it_behaves_like "syslog output"
   end
 
   context "tailing newline" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency", "message" => "%{message}\n" } }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: bar\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
 
     it_behaves_like "syslog output"
   end
 
   context "tailing carriage return and newline (windows)" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency", "message" => "%{message}\n" } }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: bar\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
 
     it_behaves_like "syslog output"
   end

--- a/spec/outputs/syslog_spec.rb
+++ b/spec/outputs/syslog_spec.rb
@@ -34,7 +34,7 @@ describe LogStash::Outputs::Syslog do
 
   context "rfc 3164 and udp by default" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency"} }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -48,7 +48,14 @@ describe LogStash::Outputs::Syslog do
 
   context "calculate priority" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "mail", "severity" => "critical"} }
-    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
+    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: bar\n/m }
+
+    it_behaves_like "syslog output"
+  end
+  
+  context "custom procid" do
+    let(:options) { {"host" => "foo", "port" => "123", "facility" => "mail", "severity" => "critical", "procid" => "123" } }
+    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[123\]: bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -72,7 +79,7 @@ describe LogStash::Outputs::Syslog do
   context "use_labels == false, default" do
     let(:event) { LogStash::Event.new({"message" => "bar", "host" => "baz" }) }
     let(:options) { {"use_labels" => false, "host" => "foo", "port" => "123" } }
-    let(:output) { /^<13>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
+    let(:output) { /^<13>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -80,7 +87,7 @@ describe LogStash::Outputs::Syslog do
   context "use_labels == false, syslog_pri" do
     let(:event) { LogStash::Event.new({"message" => "bar", "host" => "baz", "syslog_pri" => "18" }) }
     let(:options) { {"use_labels" => false, "host" => "foo", "port" => "123" } }
-    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
+    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -88,7 +95,7 @@ describe LogStash::Outputs::Syslog do
   context "use_labels == false, sprintf" do
     let(:event) { LogStash::Event.new({"message" => "bar", "host" => "baz", "priority" => "18" }) }
     let(:options) { {"use_labels" => false, "host" => "foo", "port" => "123", "priority" => "%{priority}" } }
-    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
+    let(:output) { /^<18>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -96,7 +103,7 @@ describe LogStash::Outputs::Syslog do
   context "use plain codec with format set" do
     let(:plain) { LogStash::Codecs::Plain.new({"format" => "%{host} %{message}"}) }
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency", "codec" => plain} }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: baz bar\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: baz bar\n/m }
 
     it_behaves_like "syslog output"
   end
@@ -107,7 +114,7 @@ describe LogStash::Outputs::Syslog do
     it "should write event encoded with json codec" do
       expect(subject).to receive(:connect).and_return(socket)
       expect(socket).to receive(:write) do |arg|
-        message = arg[/^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: (.*)/, 1]
+        message = arg[/^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: (.*)/, 1]
         expect(message).not_to be_nil
         message_json = JSON.parse(message)
         expect(message_json).to include("@timestamp")
@@ -121,21 +128,21 @@ describe LogStash::Outputs::Syslog do
 
   context "escape carriage return, newline and newline to \\n" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency", "message" => "foo\r\nbar\nbaz" } }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: foo\\nbar\\nbaz\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: foo\\nbar\\nbaz\n/m }
 
     it_behaves_like "syslog output"
   end
 
   context "tailing newline" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency", "message" => "%{message}\n" } }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: bar\n/m }
 
     it_behaves_like "syslog output"
   end
 
   context "tailing carriage return and newline (windows)" do
     let(:options) { {"host" => "foo", "port" => "123", "facility" => "kernel", "severity" => "emergency", "message" => "%{message}\n" } }
-    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[\]: bar\n/m }
+    let(:output) { /^<0>#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH: bar\n/m }
 
     it_behaves_like "syslog output"
   end


### PR DESCRIPTION
Hi @breml as promised regarding changed functionality.

https://discuss.elastic.co/t/logstash-output-syslog-questions-improvements-for-central-log-hub-towards-other-siem-compliancy-tool/84882

TIMESTAMP that is used is not compliant with RFC3164
TIMESTAMP that is used is not compliant with RFC3164, because the day should not have a zero-padded for day of the month, so dd should be d instead.

Example
Feb 5 17:32:18 is correct and Feb 05 17:32:18 is incorrect if I read the RFC3164 well and after testing I see some formatting issues.

See section 5.4 at IETF/RFC3164

** PID or better known as processID (procID) is optional in RFC3164**
When testing various syslog streams we see that the plugin always wants a PID , but a pid is optional when reading the section 5.3, 5.4 at IETF/RFC3164. Easiest is only insert PID with brackets ( tag[123]: after the %{pid} is available. We already have some situations that a PID (including brackets) are not in the message like following

Example
<167>May 4 14:23:23 server1 Vpxa: verbose vpxa[FFFCAB70]

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
