### PR TITLE
Priority in syslog message could be optional

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,7 +59,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_verify>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-use_labels>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-show_priority>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-use_priority>> |<<boolean,boolean>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -235,8 +235,8 @@ Verify the identity of the other end of the SSL connection against the CA.
 use label parsing for severity and facility levels
 use priority field if set to false
 
-[id="plugins-{type}s-{plugin}-show_priority"]
-===== `show_priority` 
+[id="plugins-{type}s-{plugin}-use_priority"]
+===== `use_priority` 
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -59,6 +59,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_verify>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-use_labels>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-show_priority>> |<<boolean,boolean>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -234,6 +235,13 @@ Verify the identity of the other end of the SSL connection against the CA.
 use label parsing for severity and facility levels
 use priority field if set to false
 
+[id="plugins-{type}s-{plugin}-show_priority"]
+===== `show_priority` 
+
+  * Value type is <<boolean,boolean>>
+  * Default value is `true`
+
+show priority field if set to true
 
 
 [id="plugins-{type}s-{plugin}-common-options"]

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -126,7 +126,7 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   config :rfc, :validate => ["rfc3164", "rfc5424"], :default => "rfc3164"
 
   # show priority field if set to true
-  config :show_priority, :validate => :boolean, :default => true
+  config :use_priority, :validate => :boolean, :default => true
 
   def register
     @client_socket = nil
@@ -157,7 +157,7 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
 
     message = payload.to_s.rstrip.gsub(/[\r][\n]/, "\n").gsub(/[\n]/, '\n')
 
-    if @show_priority
+    if @use_priority
       # fallback to pri 13 (facility 1, severity 5)
       if @use_labels
         facility_code = (FACILITY_LABELS.index(event.sprintf(@facility)) || 1)

--- a/logstash-output-syslog.gemspec
+++ b/logstash-output-syslog.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-syslog'
   s.version         = '3.0.5'
-  s.licenses        = ['Apache License (2.0)']
+  s.licenses        = ['Apache-2.0']
   s.summary         = "Sends events to a `syslog` server"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
   s.authors         = ["Elastic"]

--- a/spec/outputs/syslog_spec.rb
+++ b/spec/outputs/syslog_spec.rb
@@ -141,7 +141,7 @@ describe LogStash::Outputs::Syslog do
   end
 
   context "hide priority" do
-    let(:options) { {"host" => "foo", "port" => "123", "message" => "%{message}\n", "show_priority" => false } }
+    let(:options) { {"host" => "foo", "port" => "123", "message" => "%{message}\n", "use_priority" => false } }
     let(:output) { /^#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: bar\n/m }
 
     it_behaves_like "syslog output"

--- a/spec/outputs/syslog_spec.rb
+++ b/spec/outputs/syslog_spec.rb
@@ -139,4 +139,11 @@ describe LogStash::Outputs::Syslog do
 
     it_behaves_like "syslog output"
   end
+
+  context "hide priority" do
+    let(:options) { {"host" => "foo", "port" => "123", "message" => "%{message}\n", "show_priority" => false } }
+    let(:output) { /^#{RFC3164_DATE_TIME_REGEX} baz LOGSTASH\[-\]: bar\n/m }
+
+    it_behaves_like "syslog output"
+  end
 end


### PR DESCRIPTION
I need to send syslog messages to Wazuh (wazuh.com), but it doesn't parse the priority part of the message (eg. <13>). So I created an option for letting the priority part be optional.

I know this should be fixed in wazuh, but I think logstash could have this option also.


Example showing that wazuh doesn't parse it:

```
Jan 30 17:17:01 127.0.0.1 CRON[13212]: pam_unix(cron:session): session opened for user root by (uid=0)


**Phase 1: Completed pre-decoding.
       full event: 'Jan 30 17:17:01 127.0.0.1 CRON[13212]: pam_unix(cron:session): session opened for user root by (uid=0)'
       timestamp: 'Jan 30 17:17:01'
       hostname: '127.0.0.1'
       program_name: 'CRON'
       log: 'pam_unix(cron:session): session opened for user root by (uid=0)'

**Phase 2: Completed decoding.
       decoder: 'pam'
       dstuser: 'root'
       uid: '0'

**Phase 3: Completed filtering (rules).
       Rule id: '5521'
       Level: '0'
       Description: 'PAM: Ignoring Annoying Ubuntu/debian cron login events.'

<13>Jan 30 17:17:01 127.0.0.1 CRON[13212]: pam_unix(cron:session): session opened for user root by (uid=0)


**Phase 1: Completed pre-decoding.
       full event: '<13>Jan 30 17:17:01 127.0.0.1 CRON[13212]: pam_unix(cron:session): session opened for user root by (uid=0)'
       timestamp: '(null)'
       hostname: 'logserver01'
       program_name: '(null)'
       log: '<13>Jan 30 17:17:01 127.0.0.1 CRON[13212]: pam_unix(cron:session): session opened for user root by (uid=0)'

**Phase 2: Completed decoding.
       No decoder matched.

**Phase 3: Completed filtering (rules).
       Rule id: '100010'
       Level: '0'
       Description: 'token'
```