### PR TITLE
Added support for TLS SNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.6
   - Change codec instance comparison [#69](https://github.com/logstash-plugins/logstash-output-syslog/pull/69)
   - Added support for RFC5424 structured data [#67](https://github.com/logstash-plugins/logstash-output-syslog/pull/67)
+  - The SNI (Server Name Indication) extension is now used when connecting to syslog server with TLS and `host` is set to FQDN (Fully Qualified Domain Name) [#66](https://github.com/logstash-plugins/logstash-output-syslog/pull/66)
 
 ## 3.0.5
   - Docs: Set the default_codec doc attribute.

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -218,6 +218,8 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
       socket = TCPSocket.new(@host, @port)
       if ssl?
         socket = OpenSSL::SSL::SSLSocket.new(socket, @ssl_context)
+        # Use SNI extension
+        socket.hostname = @host
         begin
           socket.connect
         rescue OpenSSL::SSL::SSLError => ssle


### PR DESCRIPTION
When TLS is used to connect to the syslog server, this change adds the TLS SNI extension to the TLS handshake, to indicate the wanted server name to the server.  

Note that the `host` configuration option needs to be set to FQDN (Fully Qualified Domain Name) and not e.g. IP address or hostname without domain part.