### PR TITLE
Fix default codec instantiation

### DIFF
--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -125,17 +125,17 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   # syslog message format: you can choose between rfc3164 or rfc5424
   config :rfc, :validate => ["rfc3164", "rfc5424"], :default => "rfc3164"
 
+  default :codec, nil
+
   def register
     @client_socket = nil
 
     if ssl?
       @ssl_context = setup_ssl
     end
-    
-    if @codec.instance_of? LogStash::Codecs::Plain
-      if @codec.config["format"].nil?
-        @codec = LogStash::Codecs::Plain.new({"format" => @message})
-      end
+
+    if @codec.nil?
+      @codec = LogStash::Codecs::Plain.new({ "format" => @message })
     end
     @codec.on_event(&method(:publish))
 


### PR DESCRIPTION
This PR sets the default codec (temporarily) to `nil` to allow instantiating the default codec with `format` by testing for `nil` instead of testing for the class identity, which has not been working since logstash 7.2.0 due to https://github.com/elastic/logstash/issues/11434.

Previously #55 was created with another workaround for the class comparison issue, but it was never merged. There has not been follow-up to this issue since then (as far as I can find).

Fixes #51