### PR TITLE
Standardize SSL settings, prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 3.1.0
   - Change codec instance comparison [#69](https://github.com/logstash-plugins/logstash-output-syslog/pull/69)
   - Added support for RFC5424 structured data [#67](https://github.com/logstash-plugins/logstash-output-syslog/pull/67)
   - The SNI (Server Name Indication) extension is now used when connecting to syslog server with TLS and `host` is set to FQDN (Fully Qualified Domain Name) [#66](https://github.com/logstash-plugins/logstash-output-syslog/pull/66)
@@ -6,6 +6,7 @@
   - Added support for setting cipher suites for TLS connections [#75](https://github.com/logstash-plugins/logstash-output-syslog/pull/75)
   - Added support for setting TLS protocol versions [#77](https://github.com/logstash-plugins/logstash-output-syslog/pull/77)
   - Added support for loading PKCS8 EC private keys [#61](https://github.com/logstash-plugins/logstash-output-syslog/pull/61)
+  - Deprecated `ssl_cert` and `ssl_cacert` settings in favor of `ssl_certificate` and `ssl_certificate_authorities` [#82](https://github.com/logstash-plugins/logstash-output-syslog/pull/82)
 
 ## 3.0.5
   - Docs: Set the default_codec doc attribute.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -35,7 +35,7 @@ configuration option.
 [id="plugins-{type}s-{plugin}-options"]
 ==== Syslog Output Configuration Options
 
-This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> described later.
+This plugin supports the following configuration options plus the <<plugins-{type}s-{plugin}-common-options>> and the <<plugins-{type}s-{plugin}-deprecated-options>> described later.
 
 [cols="<,<,<",options="header",]
 |=======================================================================
@@ -53,13 +53,13 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-rfc>> |<<string,string>>, one of `["rfc3164", "rfc5424"]`|No
 | <<plugins-{type}s-{plugin}-severity>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-sourcehost>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-ssl_cacert>> |a valid filesystem path|No
-| <<plugins-{type}s-{plugin}-ssl_cert>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-ssl_certificate>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-ssl_certificate_authorities>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ssl_key>> |a valid filesystem path|No
 | <<plugins-{type}s-{plugin}-ssl_key_passphrase>> |<<password,password>>|No
 | <<plugins-{type}s-{plugin}-ssl_verify>> |<<boolean,boolean>>|No
-| <<plugins-{type}s-{plugin}-ssl_crl>> |a valid filesystem path|No
-| <<plugins-{type}s-{plugin}-ssl_crl_check_all>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-ssl_crl_path>> |a valid filesystem path|No
+| <<plugins-{type}s-{plugin}-ssl_crl_check>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ssl_cipher_suites>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-ssl_supported_protocols>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-use_labels>> |<<boolean,boolean>>|No
@@ -72,7 +72,7 @@ output plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-appname"]
-===== `appname` 
+===== `appname`
 
   * Value type is <<string,string>>
   * Default value is `"LOGSTASH"`
@@ -81,7 +81,7 @@ application name for syslog message. The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
 [id="plugins-{type}s-{plugin}-facility"]
-===== `facility` 
+===== `facility`
 
   * Value type is <<string,string>>
   * Default value is `"user-level"`
@@ -92,7 +92,7 @@ The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
 [id="plugins-{type}s-{plugin}-host"]
-===== `host` 
+===== `host`
 
   * This is a required setting.
   * Value type is <<string,string>>
@@ -101,7 +101,7 @@ to help you build a new value from other parts of the event.
 syslog server address to connect to
 
 [id="plugins-{type}s-{plugin}-message"]
-===== `message` 
+===== `message`
 
   * Value type is <<string,string>>
   * Default value is `"%{message}"`
@@ -110,7 +110,7 @@ message text to log. The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
 [id="plugins-{type}s-{plugin}-msgid"]
-===== `msgid` 
+===== `msgid`
 
   * Value type is <<string,string>>
   * Default value is `"-"`
@@ -119,7 +119,7 @@ message id for syslog message. The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port` 
+===== `port`
 
   * This is a required setting.
   * Value type is <<number,number>>
@@ -128,7 +128,7 @@ to help you build a new value from other parts of the event.
 syslog server port to connect to
 
 [id="plugins-{type}s-{plugin}-priority"]
-===== `priority` 
+===== `priority`
 
   * Value type is <<string,string>>
   * Default value is `"%{syslog_pri}"`
@@ -138,7 +138,7 @@ The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
 [id="plugins-{type}s-{plugin}-procid"]
-===== `procid` 
+===== `procid`
 
   * Value type is <<string,string>>
   * Default value is `"-"`
@@ -147,7 +147,7 @@ process id for syslog message. The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
 [id="plugins-{type}s-{plugin}-protocol"]
-===== `protocol` 
+===== `protocol`
 
   * Value can be any of: `tcp`, `udp`, `ssl-tcp`
   * Default value is `"udp"`
@@ -155,7 +155,7 @@ to help you build a new value from other parts of the event.
 syslog server protocol. you can choose between udp, tcp and ssl/tls over tcp
 
 [id="plugins-{type}s-{plugin}-reconnect_interval"]
-===== `reconnect_interval` 
+===== `reconnect_interval`
 
   * Value type is <<number,number>>
   * Default value is `1`
@@ -163,7 +163,7 @@ syslog server protocol. you can choose between udp, tcp and ssl/tls over tcp
 when connection fails, retry interval in sec.
 
 [id="plugins-{type}s-{plugin}-rfc"]
-===== `rfc` 
+===== `rfc`
 
   * Value can be any of: `rfc3164`, `rfc5424`
   * Default value is `"rfc3164"`
@@ -171,7 +171,7 @@ when connection fails, retry interval in sec.
 syslog message format: you can choose between rfc3164 or rfc5424
 
 [id="plugins-{type}s-{plugin}-severity"]
-===== `severity` 
+===== `severity`
 
   * Value type is <<string,string>>
   * Default value is `"notice"`
@@ -182,7 +182,7 @@ The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
 [id="plugins-{type}s-{plugin}-sourcehost"]
-===== `sourcehost` 
+===== `sourcehost`
 
   * Value type is <<string,string>>
   * Default value is `"%{host}"`
@@ -190,24 +190,24 @@ to help you build a new value from other parts of the event.
 source host for syslog message. The new value can include `%{foo}` strings
 to help you build a new value from other parts of the event.
 
-[id="plugins-{type}s-{plugin}-ssl_cacert"]
-===== `ssl_cacert` 
-
-  * Value type is <<path,path>>
-  * There is no default value for this setting.
-
-The SSL CA certificate, chainfile or CA path. The system CA path is automatically included.
-
-[id="plugins-{type}s-{plugin}-ssl_cert"]
-===== `ssl_cert` 
+[id="plugins-{type}s-{plugin}-ssl_certificate"]
+===== `ssl_certificate`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
 
 SSL certificate path
 
+[id="plugins-{type}s-{plugin}-ssl_certificate_authorities"]
+===== `ssl_certificate_authorities`
+
+  * Value type is a list of <<path,path>>
+  * There is no default value for this setting
+
+List of SSL CA certificate, chainfile or CA path. The system CA path is automatically included.
+
 [id="plugins-{type}s-{plugin}-ssl_key"]
-===== `ssl_key` 
+===== `ssl_key`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -215,7 +215,7 @@ SSL certificate path
 SSL key path
 
 [id="plugins-{type}s-{plugin}-ssl_key_passphrase"]
-===== `ssl_key_passphrase` 
+===== `ssl_key_passphrase`
 
   * Value type is <<password,password>>
   * Default value is `nil`
@@ -223,15 +223,15 @@ SSL key path
 SSL key passphrase
 
 [id="plugins-{type}s-{plugin}-ssl_verify"]
-===== `ssl_verify` 
+===== `ssl_verify`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
 
 Verify the identity of the other end of the SSL connection against the CA.
 
-[id="plugins-{type}s-{plugin}-ssl_crl"]
-===== `ssl_crl`
+[id="plugins-{type}s-{plugin}-ssl_crl_path"]
+===== `ssl_crl_path`
 
   * Value type is <<path,path>>
   * There is no default value for this setting.
@@ -239,14 +239,15 @@ Verify the identity of the other end of the SSL connection against the CA.
 SSL CRL path for checking the revocation status of the server certificate.
 File may contain one or more PEM encoded CRLs.
 
-[id="plugins-{type}s-{plugin}-ssl_crl_check_all"]
-===== `ssl_crl_check_all`
+[id="plugins-{type}s-{plugin}-ssl_crl_check"]
+===== `ssl_crl_check`
 
-  * Value type is <<boolean,boolean>>
-  * Default value is `false`
+  * Value type is <<array,array>>
+  * There is no default value for this setting
 
-If this option is set to false, only the certificate at the end of the certificate chain will be subject to validation by CRL.
-If set to true the complete chain is validated. CRLs must be available from all CAs.
+When empty (default), only the certificate at the end of the certificate chain will be subject to validation by CRL.
+Set to `'chain'` to validate the complete certificate chain against CRLs.
+CRLs must be available from all Certificate Authorities that are to be validated.
 
 [id="plugins-{type}s-{plugin}-ssl_cipher_suites"]
 ===== `ssl_cipher_suites`
@@ -275,7 +276,7 @@ the protocol is disabled by default and needs to be enabled manually by changing
 the *$JDK_HOME/conf/security/java.security* configuration file. That is, `TLSv1.1` needs to be removed from the list.
 
 [id="plugins-{type}s-{plugin}-use_labels"]
-===== `use_labels` 
+===== `use_labels`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`
@@ -296,6 +297,37 @@ The elements need to be formatted according to link:https://datatracker.ietf.org
   `[exampleSDID@32473 iut="3" eventSource="Application" eventID="1011"][examplePriority@32473 class="high"]`
 
 The new value can include `%{foo}` strings to help you build a new value from other parts of the event.
+
+[id="plugins-{type}s-{plugin}-deprecated-options"]
+==== Deprecated Configuration Options
+
+WARNING: Deprecated options are subject to removal in future releases.
+
+[cols="<,<,<",options="header",]
+|=======================================================================
+|Setting|Input type|Replaced by
+| <<plugins-{type}s-{plugin}-ssl_cacert>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_certificate_authorities>>
+| <<plugins-{type}s-{plugin}-ssl_cert>> |a valid filesystem path|<<plugins-{type}s-{plugin}-ssl_certificate>>
+|=======================================================================
+
+[id="plugins-{type}s-{plugin}-ssl_cacert"]
+===== `ssl_cacert`
+deprecated[3.1.0 Replaced by <<plugins-{type}s-{plugin}-ssl_certificate_authorities>>]
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+The SSL CA certificate, chainfile or CA path. The system CA path is automatically included.
+
+[id="plugins-{type}s-{plugin}-ssl_cert"]
+===== `ssl_cert`
+deprecated[3.1.0 Replaced by <<plugins-{type}s-{plugin}-ssl_certificate>>]
+
+  * Value type is <<path,path>>
+  * There is no default value for this setting.
+
+SSL certificate path
+
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -243,11 +243,11 @@ File may contain one or more PEM encoded CRLs.
 ===== `ssl_crl_check`
 
   * Value type is <<array,array>>
-  * There is no default value for this setting
+  * Default value is `['leaf']`
 
-When empty (default), only the certificate at the end of the certificate chain will be subject to validation by CRL.
-Set to `'chain'` to validate the complete certificate chain against CRLs.
-CRLs must be available from all Certificate Authorities that are to be validated.
+When set to `leaf` (default), only the server certificate is validated against CRLs.
+When set to `chain`, the entire certificate chain, including subordinate Certificate Authorities, is validated against CRLs.
+For each certificate validated, a CRL from its issuing Certificate Authority must be present in the <<plugins-{type}s-{plugin}-ssl_crl_path>>.
 
 [id="plugins-{type}s-{plugin}-ssl_cipher_suites"]
 ===== `ssl_cipher_suites`

--- a/lib/logstash/outputs/syslog.rb
+++ b/lib/logstash/outputs/syslog.rb
@@ -3,6 +3,7 @@ require "logstash/outputs/base"
 require "logstash/namespace"
 require "date"
 require "logstash/codecs/plain"
+require "logstash/plugin_mixins/normalize_config_support"
 
 
 # Send events to a syslog server.
@@ -16,6 +17,8 @@ require "logstash/codecs/plain"
 # reason want to change the emitted message, modify the `message`
 # configuration option.
 class LogStash::Outputs::Syslog < LogStash::Outputs::Base
+  include LogStash::PluginMixins::NormalizeConfigSupport
+
   config_name "syslog"
 
   FACILITY_LABELS = [
@@ -72,10 +75,16 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   config :ssl_verify, :validate => :boolean, :default => false
 
   # The SSL CA certificate, chainfile or CA path. The system CA path is automatically included.
-  config :ssl_cacert, :validate => :path
+  config :ssl_cacert, :validate => :path, :deprecated => "Use 'ssl_certificate_authorities' instead."
+
+  # The SSL CA certificate, chainfile or CA path. The system CA path is automatically included.
+  config :ssl_certificate_authorities, :validate => :path, :list => true
 
   # SSL certificate path
-  config :ssl_cert, :validate => :path
+  config :ssl_cert, :validate => :path, :deprecated => "Use 'ssl_certificate' instead."
+
+  # SSL certificate path
+  config :ssl_certificate, :validate => :path
 
   # SSL key path
   config :ssl_key, :validate => :path
@@ -84,10 +93,12 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   config :ssl_key_passphrase, :validate => :password, :default => nil
 
   # CRL file or bundle of CRLs
-  config :ssl_crl, :validate => :path
+  config :ssl_crl_path, :validate => :path
 
-  # Check CRL for only leaf certificate (false) or require CRL check for the complete chain (true)
-  config :ssl_crl_check_all, :validate => :boolean, :default => false
+  # CRL check flags.
+  # When empty (default), only the certificate at the end of the certificate chain will be subject to validation by CRL.
+  # Set to 'chain' to validate the complete certificate chain against CRLs.
+  config :ssl_crl_check, :validate => ["chain"], :list => true, :default => []
 
   # The list of cipher suites to use, listed by priorities.
   # Supported cipher suites vary depending on which version of Java is used.
@@ -144,6 +155,16 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   config :structured_data, :validate => :string, :default => ""
 
   def register
+    @ssl_certificate_authorities = normalize_config(:ssl_certificate_authorities) do |normalize|
+      normalize.with_deprecated_mapping(:ssl_cacert) do |ssl_cacert|
+        [ssl_cacert]
+      end
+    end
+
+    @ssl_certificate = normalize_config(:ssl_certificate) do |normalize|
+      normalize.with_deprecated_alias(:ssl_cert)
+    end
+
     @client_socket = nil
 
     if ssl?
@@ -258,25 +279,29 @@ class LogStash::Outputs::Syslog < LogStash::Outputs::Base
   def setup_ssl
     require "openssl"
     ssl_context = OpenSSL::SSL::SSLContext.new
-    ssl_context.cert = OpenSSL::X509::Certificate.new(File.read(@ssl_cert))
+    ssl_context.cert = OpenSSL::X509::Certificate.new(File.read(@ssl_certificate))
     ssl_context.key = OpenSSL::PKey::read(File.read(@ssl_key),@ssl_key_passphrase)
     ssl_context.ciphers = @ssl_cipher_suites if @ssl_cipher_suites&.any?
     if @ssl_verify
       cert_store = OpenSSL::X509::Store.new
       # Load the system default certificate path to the store
       cert_store.set_default_paths
-      if File.directory?(@ssl_cacert)
-        cert_store.add_path(@ssl_cacert)
-      else
-        cert_store.add_file(@ssl_cacert)
+      if @ssl_certificate_authorities
+        @ssl_certificate_authorities.each do |ca_path|
+          if File.directory?(ca_path)
+            cert_store.add_path(ca_path)
+          else
+            cert_store.add_file(ca_path)
+          end
+        end
       end
-      if @ssl_crl
+      if @ssl_crl_path
         # copy the behavior of X509_load_crl_file() which supports loading bundles of CRLs.
-        File.read(@ssl_crl).split(CRL_END_TAG).each do |crl|
+        File.read(@ssl_crl_path).split(CRL_END_TAG).each do |crl|
           crl << CRL_END_TAG
           cert_store.add_crl(OpenSSL::X509::CRL.new(crl))
         end
-        cert_store.flags = @ssl_crl_check_all ? OpenSSL::X509::V_FLAG_CRL_CHECK|OpenSSL::X509::V_FLAG_CRL_CHECK_ALL : OpenSSL::X509::V_FLAG_CRL_CHECK
+        cert_store.flags = @ssl_crl_check.include?("chain") ? OpenSSL::X509::V_FLAG_CRL_CHECK|OpenSSL::X509::V_FLAG_CRL_CHECK_ALL : OpenSSL::X509::V_FLAG_CRL_CHECK
       end
       ssl_context.cert_store = cert_store
       ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER|OpenSSL::SSL::VERIFY_FAIL_IF_NO_PEER_CERT

--- a/logstash-output-syslog.gemspec
+++ b/logstash-output-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-syslog'
-  s.version         = '3.0.6'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Sends events to a `syslog` server"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'logstash-mixin-normalize_config_support'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-json'
 end
-

--- a/spec/outputs/syslog_tls_spec.rb
+++ b/spec/outputs/syslog_tls_spec.rb
@@ -104,6 +104,17 @@ describe LogStash::Outputs::Syslog do
         it_behaves_like "syslog output"
       end
 
+      context "with deprecated ssl_cert and ssl_cacert" do
+        # Override parent options to test only deprecated options.
+        let(:options) { { "host" => "localhost", "port" => port, "protocol" => "ssl-tcp", "ssl_verify" => true,
+          "ssl_cert" => File.join(FIXTURES_PATH, "client.pem"),
+          "ssl_key" => File.join(FIXTURES_PATH, "client-key.pem"),
+          "ssl_cacert" => File.join(FIXTURES_PATH, "ca.pem")
+        } }
+
+        it_behaves_like "syslog output"
+      end
+
     end
 
     context "server with untrusted certificates" do
@@ -129,14 +140,26 @@ describe LogStash::Outputs::Syslog do
     end
 
     context "server with revoked certificates" do
-      let(:options ) { super().merge("ssl_verify" => true, "ssl_crl" => File.join(FIXTURES_PATH, "ca-crl.pem")) }
+      let(:options ) { super().merge("ssl_verify" => true, "ssl_crl_path" => File.join(FIXTURES_PATH, "ca-crl.pem")) }
       let(:server_cert_file) { File.join(FIXTURES_PATH, "revoked-server.pem") }
       let(:server_pkey_file) { File.join(FIXTURES_PATH, "revoked-server-key.pem") }
 
-      it "syslog output refuses to connect" do
-        Thread.start { secure_server.accept rescue nil }
-        expect(subject.logger).to receive(:error).with(/SSL Error/i, hash_including(exception: OpenSSL::SSL::SSLError)).once.and_throw :TEST_DONE
-        expect { subject.receive event }.to throw_symbol(:TEST_DONE)
+      shared_examples "refuses connection" do
+        it "syslog output refuses to connect" do
+          Thread.start { secure_server.accept rescue nil }
+          expect(subject.logger).to receive(:error).with(/SSL Error/i, hash_including(exception: OpenSSL::SSL::SSLError)).once.and_throw :TEST_DONE
+          expect { subject.receive event }.to throw_symbol(:TEST_DONE)
+        end
+      end
+
+      context "with default ssl_crl_check" do
+        it_behaves_like "refuses connection"
+      end
+
+      context "with chain ssl_crl_check" do
+        let(:options ) { super().merge("ssl_crl_check" => ["chain"]) }
+
+        it_behaves_like "refuses connection"
       end
     end
   end
@@ -146,10 +169,10 @@ describe LogStash::Outputs::Syslog do
 
     context "RSA certificate and private key" do
       let(:options ) { super().merge(
-        "ssl_cert" => File.join(FIXTURES_PATH, "client.pem"),
+        "ssl_certificate" => File.join(FIXTURES_PATH, "client.pem"),
         "ssl_key" => File.join(FIXTURES_PATH, "client-key.pem"),
-        "ssl_cacert" => File.join(FIXTURES_PATH, "ca.pem"),
-        "ssl_crl"  => File.join(FIXTURES_PATH, "ca-crl.pem")
+        "ssl_certificate_authorities" => [File.join(FIXTURES_PATH, "ca.pem")],
+        "ssl_crl_path"  => File.join(FIXTURES_PATH, "ca-crl.pem")
       ) }
 
       it "register succeeds" do
@@ -159,10 +182,10 @@ describe LogStash::Outputs::Syslog do
 
     context "EC certificate and private key" do
       let(:options ) { super().merge(
-        "ssl_cert" => File.join(FIXTURES_PATH, "client-ec.pem"),
+        "ssl_certificate" => File.join(FIXTURES_PATH, "client-ec.pem"),
         "ssl_key" => File.join(FIXTURES_PATH, "client-ec-key.pem"),
-        "ssl_cacert" => File.join(FIXTURES_PATH, "ca.pem"),
-        "ssl_crl"  => File.join(FIXTURES_PATH, "ca-crl.pem")
+        "ssl_certificate_authorities" => [File.join(FIXTURES_PATH, "ca.pem")],
+        "ssl_crl_path"  => File.join(FIXTURES_PATH, "ca-crl.pem")
       ) }
 
       it "register succeeds" do
@@ -172,10 +195,10 @@ describe LogStash::Outputs::Syslog do
 
     context "invalid client certificate" do
       let(:options ) { super().merge(
-        "ssl_cert" => File.join(FIXTURES_PATH, "invalid.pem"),
+        "ssl_certificate" => File.join(FIXTURES_PATH, "invalid.pem"),
         "ssl_key" => File.join(FIXTURES_PATH, "client-key.pem"),
-        "ssl_cacert" => File.join(FIXTURES_PATH, "ca.pem"),
-        "ssl_crl"  => File.join(FIXTURES_PATH, "ca-crl.pem")
+        "ssl_certificate_authorities" => [File.join(FIXTURES_PATH, "ca.pem")],
+        "ssl_crl_path"  => File.join(FIXTURES_PATH, "ca-crl.pem")
       ) }
 
       it "register raises error" do
@@ -185,10 +208,10 @@ describe LogStash::Outputs::Syslog do
 
     context "invalid client private key" do
       let(:options ) { super().merge(
-        "ssl_cert" => File.join(FIXTURES_PATH, "client.pem"),
+        "ssl_certificate" => File.join(FIXTURES_PATH, "client.pem"),
         "ssl_key" => File.join(FIXTURES_PATH, "invalid.pem"),
-        "ssl_cacert" => File.join(FIXTURES_PATH, "ca.pem"),
-        "ssl_crl"  => File.join(FIXTURES_PATH, "ca-crl.pem")
+        "ssl_certificate_authorities" => [File.join(FIXTURES_PATH, "ca.pem")],
+        "ssl_crl_path"  => File.join(FIXTURES_PATH, "ca-crl.pem")
       ) }
 
       it "register raises error" do
@@ -198,10 +221,10 @@ describe LogStash::Outputs::Syslog do
 
     context "invalid CRL" do
       let(:options ) { super().merge(
-        "ssl_cert" => File.join(FIXTURES_PATH, "client.pem"),
+        "ssl_certificate" => File.join(FIXTURES_PATH, "client.pem"),
         "ssl_key" => File.join(FIXTURES_PATH, "client-key.pem"),
-        "ssl_cacert" => File.join(FIXTURES_PATH, "ca.pem"),
-        "ssl_crl"  => File.join(FIXTURES_PATH, "invalid.pem")
+        "ssl_certificate_authorities" => [File.join(FIXTURES_PATH, "ca.pem")],
+        "ssl_crl_path"  => File.join(FIXTURES_PATH, "invalid.pem")
       ) }
 
       it "register raises error" do


### PR DESCRIPTION
* Deprecated `ssl_cert` and `ssl_cacert` settings in favor of `ssl_certificate` and `ssl_certificate_authorities`
  * xref https://github.com/elastic/logstash/issues/14924
* Renamed `ssl_crl` to `ssl_crl_path`.
  * No deprecation required, since this option was not part of any released version.
* Replaced the boolean `ssl_crl_check_all` flag with an array-based `ssl_crl_check` setting, making it possible to extend CRL checking options in the future.
  * No deprecation required, since this option was not part of any released version.
* Updated tests and documentation to reflect the updated configuration options.
* Bumped the version to the next minor release (`3.1.0`) in both the CHANGELOG and gemspec.

Fixes #81
